### PR TITLE
Add hex and base64 support to Hash.update()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,20 @@ export class Hash {
         // TODO: TypedArray
         if (data instanceof DataView)
             throw new Error("DataView not yet supported");
-        if (inputEncoding !== undefined)
+
+        else if (typeof data == "string" && inputEncoding === "hex") {
+            if(data.length % 2 != 0)
+                throw new Error(`Hex must be even length, got length: ${data.length}`);
+
+            // This is stricter than node as node ignores invalid hex-strings (except length).
+            if (!/^[0-9A-Fa-f]*$/g.test(data))
+                throw new Error(`Hex must be 0-9 or a-f`);
+            data = new Buffer(data, inputEncoding);
+        }
+        else if (typeof data == "string" && inputEncoding === "base64") {
+            data = new Buffer(data, inputEncoding);
+        }
+        else if (inputEncoding !== undefined)
             throw new Error("inputEncoding not yet supported");
 
         if (data instanceof Buffer)

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -17,9 +17,15 @@ function digest() {
 }
 
 function update() {
-    const hash = helloSha512();
-    hash.update("hello world");
-    assert(hash.digest("hex") !== helloWorldSha);
+    assert(helloSha512().update("hello world").digest("hex") !== helloWorldSha);
+
+    const hexHash = crypto.createHash("md5").update("dc10ae47cb1686d7e7b4f54363b51ced0cd40b0c", "hex");
+    assert(hexHash.digest("hex") == "0cd258c4493108f6e4ad3c0a4d937f2f")
+    assertThrows(() => crypto.createHash("md5").update("1", "hex"));
+    assertThrows(() => crypto.createHash("md5").update("BOOM", "hex"));
+
+    const b64Hash = crypto.createHash("md5").update("3BCuR8sWhtfntPVDY7Uc7QzUCww=", "base64");
+    assert(b64Hash.digest("hex") == "0cd258c4493108f6e4ad3c0a4d937f2f")
 }
 
 function digestThrows() {


### PR DESCRIPTION
Adds hex and base64 to update().
Note: node behaves a bit weird in hex case, it seems to only validate input length and updates digest until first non-valid hex is reached.

Instead of replicating this I'm validating and throwing (at the cost of running a regex)

```typescript
const { default: crypto } = await import("crypto");
crypto.createHash("md5").update("glam", "hex").digest("hex") == crypto.createHash("md5").digest("hex")
// true



crypto.createHash("md5").update("ba", "hex").digest("hex") == crypto.createHash("md5").update("banana", "hex").digest("hex")
// true

```
